### PR TITLE
add Windows packages and win-arm files support

### DIFF
--- a/decode-ref.js
+++ b/decode-ref.js
@@ -1,10 +1,14 @@
 const assert = require('assert')
-    , dirre  = /^(v\d+\.\d+\.\d+(?:-rc\.\d+)?)(?:-(?:(?:next-)?nightly|test)\d{8}(\w+))?$/ // get version or commit from dir name
+    , dirre  = /^(v\d+\.\d+\.\d+(?:-rc\.\d+)?)(?:-((?:next-)?nightly|test|v8-canary)\d{8}(\w+))?$/ // get version or commit from dir name
 
 
 function decodeRef (dir) {
   var m = dir.match(dirre)
-  return m && (m[2] || m[1])
+  if (!m)
+    return null
+  if (!m[2])
+    return `node/${m[1]}`
+  return `${m[2] == 'v8-canary' ? 'v8-canary' : 'node'}/${m[3]}`
 }
 
 
@@ -13,15 +17,16 @@ module.exports = decodeRef
 
 if (module === require.main) {
   var tests = [
-      { dir: 'v1.0.0'                                , ref: 'v1.0.0'          }
-    , { dir: 'v10.11.12'                             , ref: 'v10.11.12'       }
-    , { dir: 'v2.3.2-nightly20150625dcbb9e1da6'      , ref: 'dcbb9e1da6'      }
-    , { dir: 'v2.3.1-next-nightly201506308f6f4280c6' , ref: '8f6f4280c6'      }
-    , { dir: 'v3.0.0-rc.1'                           , ref: 'v3.0.0-rc.1'     }
-    , { dir: 'v33.22.1-rc.111'                       , ref: 'v33.22.1-rc.111' }
-    , { dir: 'v0.6.1'                                , ref: 'v0.6.1'          }
-    , { dir: 'v0.5.1'                                , ref: 'v0.5.1'          }
-    , { dir: 'v6.0.0-test20151107093b0e865c'         , ref: '093b0e865c'      }
+      { dir: 'v1.0.0'                                , ref: 'node/v1.0.0'          }
+    , { dir: 'v10.11.12'                             , ref: 'node/v10.11.12'       }
+    , { dir: 'v2.3.2-nightly20150625dcbb9e1da6'      , ref: 'node/dcbb9e1da6'      }
+    , { dir: 'v2.3.1-next-nightly201506308f6f4280c6' , ref: 'node/8f6f4280c6'      }
+    , { dir: 'v3.0.0-rc.1'                           , ref: 'node/v3.0.0-rc.1'     }
+    , { dir: 'v33.22.1-rc.111'                       , ref: 'node/v33.22.1-rc.111' }
+    , { dir: 'v0.6.1'                                , ref: 'node/v0.6.1'          }
+    , { dir: 'v0.5.1'                                , ref: 'node/v0.5.1'          }
+    , { dir: 'v6.0.0-test20151107093b0e865c'         , ref: 'node/093b0e865c'      }
+    , { dir: 'v9.0.0-v8-canary20170609cd40078f1f'    , ref: 'v8-canary/cd40078f1f' }
   ]
 
   tests.forEach(function (test) {

--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -81,12 +81,16 @@ function cachePut (gitref, prop, value) {
 
 
 function fetch (url, gitref, callback) {
-  let repo = (/^v0\.\d\./).test(gitref)
-             ? 'node-v0.x-archive'
-             : 'node'
-  url = url.replace('{gitref}', gitref)
+  let refparts = gitref.split('/')
+  let repo = refparts[0] == 'v8-canary'
+             ? 'node-v8'
+             : (/^v0\.\d\./).test(refparts[1])
+               ? 'node-v0.x-archive'
+               : 'node'
+
+  url = url.replace('{gitref}', refparts[1])
            .replace('{repo}', repo)
-           + `?rev=${gitref}`
+           + `?rev=${refparts[1]}`
   hyperquest.get(url, githubOptions).pipe(bl(function (err, data) {
     if (err)
       return callback(err)
@@ -98,7 +102,7 @@ function fetch (url, gitref, callback) {
 
 function fetchNpmVersion (gitref, callback) {
   var version = cacheGet(gitref, 'npm')
-  if (version || (/^v0\.([012345]\.\d+|6\.[0-2])$/).test(gitref))
+  if (version || (/\/v0\.([012345]\.\d+|6\.[0-2])$/).test(gitref))
     return setImmediate(callback.bind(null, null, version))
 
   fetch(npmPkgJsonUrl, gitref, function (err, rawData) {
@@ -160,7 +164,7 @@ function fetchV8Version (gitref, callback) {
 
 function fetchUvVersion (gitref, callback) {
   var version = cacheGet(gitref, 'uv')
-  if (version || (/^v0\.([01234]\.\d+|5\.0)$/).test(gitref))
+  if (version || (/\/v0\.([01234]\.\d+|5\.0)$/).test(gitref))
     return setImmediate(callback.bind(null, null, version))
 
   fetch(uvVersionUrl[0], gitref, function (err, rawData) {
@@ -216,7 +220,7 @@ function fetchUvVersion (gitref, callback) {
 
 function fetchSslVersion (gitref, callback) {
   var version = cacheGet(gitref, 'ssl')
-  if (version || (/^v0\.([01234]\.\d+|5\.[0-4])$/).test(gitref))
+  if (version || (/\/v0\.([01234]\.\d+|5\.[0-4])$/).test(gitref))
     return setImmediate(callback.bind(null, null, version))
 
   fetch(sslVersionUrl[0], gitref, function (err, rawData) {
@@ -249,7 +253,7 @@ function fetchSslVersion (gitref, callback) {
 
 function fetchZlibVersion (gitref, callback) {
   var version = cacheGet(gitref, 'zlib')
-  if (version || (/^v0\.([01234]\.\d+|5\.[0-7])$/).test(gitref))
+  if (version || (/\/v0\.([01234]\.\d+|5\.[0-7])$/).test(gitref))
     return setImmediate(callback.bind(null, null, version))
 
   fetch(zlibVersionUrl, gitref, function (err, rawData) {
@@ -267,7 +271,7 @@ function fetchZlibVersion (gitref, callback) {
 
 function fetchModVersion (gitref, callback) {
   var version = cacheGet(gitref, 'mod')
-  if (version || (/^v0\.1\.\d+$/).test(gitref))
+  if (version || (/\/v0\.1\.\d+$/).test(gitref))
     return setImmediate(callback.bind(null, null, version))
 
   fetch(modVersionUrl[0], gitref, function (err, rawData) {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "after": "~0.8.2",
-    "bl": "~1.1.2",
-    "hyperquest": "~1.0.1",
+    "bl": "~1.2.1",
+    "hyperquest": "~2.1.2",
     "map-async": "~0.1.1",
     "minimist": "~1.2.0",
     "semver": "~5.3.0"

--- a/transform-filename.js
+++ b/transform-filename.js
@@ -28,7 +28,7 @@ const assert = require('assert')
 
 
 function transformFilename (file) {
-  file = file && file.replace(/^(?:\.\/)?(?:iojs|node)-v\d+\.\d+\.\d+-?((rc\.\d+|(next-)?nightly\d{8}[^-\.]+)-?)?\.?/, '')
+  file = file && file.replace(/^(?:\.\/)?(?:iojs|node)-v\d+\.\d+\.\d+-?((rc\.\d+|(?:(next-)?nightly|test|v8-canary)\d{8}[^-\.]+)-?)?\.?/, '')
                      .replace(/\.tar\.gz$/, '')
   return types[file]
 }
@@ -125,6 +125,14 @@ if (module === require.main) {
     , { file: 'node-v0.11.9.tar.gz', type: 'src' }
     , { file: 'node.exe', type: 'win-x86-exe' }
     , { file: 'x64/node.exe', type: 'win-x64-exe' }
+    , { file: 'node-v9.0.0-v8-canary20170609cd40078f1f-darwin-x64.tar.gz', type: 'osx-x64-tar' }
+    , { file: 'node-v9.0.0-v8-canary20170609cd40078f1f-darwin-x64.tar.xz' }
+    , { file: 'node-v9.0.0-v8-canary20170609cd40078f1f-headers.tar.gz', type: 'headers' }
+    , { file: 'node-v9.0.0-v8-canary20170609cd40078f1f-headers.tar.xz' }
+    , { file: 'node-v9.0.0-test20170609cd40078f1f-darwin-x64.tar.gz', type: 'osx-x64-tar' }
+    , { file: 'node-v9.0.0-test20170609cd40078f1f-darwin-x64.tar.xz' }
+    , { file: 'node-v9.0.0-test20170609cd40078f1f-headers.tar.gz', type: 'headers' }
+    , { file: 'node-v9.0.0-test20170609cd40078f1f-headers.tar.xz' }
   ]
 
   tests.forEach(function (test) {

--- a/transform-filename.js
+++ b/transform-filename.js
@@ -19,10 +19,18 @@ const assert = require('assert')
         , 'x86.msi'          : 'win-x86-msi'
         , 'win-x64/iojs.exe' : 'win-x64-exe'
         , 'win-x86/iojs.exe' : 'win-x86-exe'
+        , 'win-arm/iojs.exe' : 'win-arm-exe'
         , 'win-x64/node.exe' : 'win-x64-exe'
         , 'win-x86/node.exe' : 'win-x86-exe'
+        , 'win-arm/node.exe' : 'win-arm-exe'
         , 'node.exe'         : 'win-x86-exe'
         , 'x64/node.exe'     : 'win-x64-exe'
+        , 'win-x64.7z'       : 'win-x64-7z'
+        , 'win-x86.7z'       : 'win-x86-7z'
+        , 'win-arm.7z'       : 'win-arm-7z'
+        , 'win-x64.zip'      : 'win-x64-zip'
+        , 'win-x86.zip'      : 'win-x86-zip'
+        , 'win-arm.zip'      : 'win-arm-zip'
         , 'headers'          : 'headers'
       }
 
@@ -133,6 +141,13 @@ if (module === require.main) {
     , { file: 'node-v9.0.0-test20170609cd40078f1f-darwin-x64.tar.xz' }
     , { file: 'node-v9.0.0-test20170609cd40078f1f-headers.tar.gz', type: 'headers' }
     , { file: 'node-v9.0.0-test20170609cd40078f1f-headers.tar.xz' }
+    , { file: 'win-arm/node.exe', type: 'win-arm-exe' }
+    , { file: 'node-v8.1.4-win-arm.7z', type: 'win-arm-7z' }
+    , { file: 'node-v8.1.4-win-arm.zip', type: 'win-arm-zip' }
+    , { file: 'node-v8.1.4-win-x64.7z', type: 'win-x64-7z' }
+    , { file: 'node-v8.1.4-win-x64.zip', type: 'win-x64-zip' }
+    , { file: 'node-v8.1.4-win-x86.7z', type: 'win-x86-7z' }
+    , { file: 'node-v8.1.4-win-x86.zip', type: 'win-x86-zip' }
   ]
 
   tests.forEach(function (test) {


### PR DESCRIPTION
Add support for Windows binary package distribution files (zip and 7z).
Add support for Windows arm binary distribution files (currently used in "Node.js on ChakraCore" releases).
Add tests to transform-filename.js.

This PR includes the commit under review in https://github.com/nodejs/nodejs-dist-indexer/pull/4 by @rvagg , so this can be easily rebased after that PR lands.