### PR TITLE
dist-indexer: fix libuv version generation

### DIFF
--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -214,21 +214,21 @@ function fetchUvVersion (gitref, callback) {
           cachePut(gitref, 'uv', version)
           return callback(null, version)
         }
-      })
 
-      fetch(uvVersionUrl[3], gitref, function (err, rawData) {
-        if (err)
-          return callback(err)
+        fetch(uvVersionUrl[3], gitref, function (err, rawData) {
+          if (err)
+            return callback(err)
 
-        version = rawData.split('\n').map(function (line) {
-            return line.match(/^#define UV_VERSION_(?:MAJOR|MINOR|PATCH)\s+(\d+)$/)
-          })
-          .filter(Boolean)
-          .map(function (m) { return m[1] })
-          .join('.')
+          version = rawData.split('\n').map(function (line) {
+              return line.match(/^#define UV_VERSION_(?:MAJOR|MINOR|PATCH)\s+(\d+)$/)
+            })
+            .filter(Boolean)
+            .map(function (m) { return m[1] })
+            .join('.')
 
-        cachePut(gitref, 'uv', version)
-        callback(null, version)
+          cachePut(gitref, 'uv', version)
+          callback(null, version)
+        })
       })
     })
   })

--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -27,6 +27,7 @@ const fs         = require('fs')
           `${githubContentUrl}/deps/uv/include/uv-version.h`
         , `${githubContentUrl}/deps/uv/src/version.c`
         , `${githubContentUrl}/deps/uv/include/uv.h`
+        , `${githubContentUrl}/deps/uv/include/uv/version.h`
       ]
     , sslVersionUrl    = [
           `${githubContentUrl}/deps/openssl/openssl/include/openssl/opensslv.h`
@@ -161,7 +162,6 @@ function fetchV8Version (gitref, callback) {
   })
 }
 
-
 function fetchUvVersion (gitref, callback) {
   var version = cacheGet(gitref, 'uv')
   if (version || (/\/v0\.([01234]\.\d+|5\.0)$/).test(gitref))
@@ -200,6 +200,23 @@ function fetchUvVersion (gitref, callback) {
       }
 
       fetch(uvVersionUrl[2], gitref, function (err, rawData) {
+        if (err)
+          return callback(err)
+
+        version = rawData.split('\n').map(function (line) {
+            return line.match(/^#define UV_VERSION_(?:MAJOR|MINOR|PATCH)\s+(\d+)$/)
+          })
+          .filter(Boolean)
+          .map(function (m) { return m[1] })
+          .join('.')
+
+        if (version) {
+          cachePut(gitref, 'uv', version)
+          return callback(null, version)
+        }
+      })
+
+      fetch(uvVersionUrl[3], gitref, function (err, rawData) {
         if (err)
           return callback(err)
 


### PR DESCRIPTION
Beginning in nodejs/node@537a4baa443daea9850a8e324b5b4d7c21dd2717,
`deps/uv/include/uv-version.h` moved to `deps/uv/include/uv/version.h`, so add
that as a possible path where libuv's version might be stored.

Refs: https://github.com/nodejs/node/pull/21466

---

Unrelated note, but cc @Trott in case there are folks looking to get involved somewhere in Node, this is a low visibility with super high impact codebase (in JS) that could use some good refactoring. Happy to help mentor/review PRs if there are any takers...