### PR TITLE
add security release column to index

### DIFF
--- a/is-security-release.js
+++ b/is-security-release.js
@@ -1,0 +1,34 @@
+const notesre = /Version \d+\.\d+\.\d+.*\n(?!\w+<\/title>)\n(.*)\n/m
+    , securityre = /This is a security release\./
+
+
+function isSecurityRelease (notes) {
+  const m = notes.match(notesre)
+  if (m && securityre.test(m[1]))
+    return true
+
+  return false
+}
+
+
+module.exports = isSecurityRelease
+
+
+if (module === require.main) {
+  const assert = require('assert')
+  const fs = require('fs')
+  const path = require('path')
+  const fixturespath = path.join(__dirname, 'test', 'fixtures', 'release-notes')
+  const tests = [
+      { fixture: 'v10.14.0.atom', expected: true }
+    , { fixture: 'v10.14.1.atom', expected: false }
+    , { fixture: 'v11.3.0.atom' , expected: true }
+  ]
+
+  tests.forEach(function (test) {
+    console.log(`testing ${test.fixture} -> ${test.expected}`)
+    const fixture = path.join(fixturespath, test.fixture)
+    const notes = fs.readFileSync(fixture, { encoding: 'utf8' })
+    assert.equal(isSecurityRelease(notes), test.expected)
+  })
+}

--- a/test/fixtures/release-notes/v10.14.0.atom
+++ b/test/fixtures/release-notes/v10.14.0.atom
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:/nodejs/node/commits/v10.14.0</id>
+  <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commits/v10.14.0"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/nodejs/node/commits/v10.14.0.atom"/>
+  <title>Recent Commits to node:v10.14.0</title>
+  <updated>2018-11-27T22:17:04Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b7103135bc7987dee97e8795b0b38293d05fd842</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/b7103135bc7987dee97e8795b0b38293d05fd842"/>
+    <title>
+        2018-11-27, Version 10.14.0 &#39;Dubnium&#39; (LTS)
+    </title>
+    <updated>2018-11-27T22:17:04Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-11-27, Version 10.14.0 &amp;#39;Dubnium&amp;#39; (LTS)
+
+This is a security release. All Node.js users should consult the security
+release summary at:
+
+  https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/
+
+for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+  * Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+  * Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+  * Node.js: Hostname spoofing in URL parser for javascript protocol
+    (CVE-2018-12123)
+  * OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+  * OpenSSL: Timing vulnerability in ECDSA signature generation (CVE-2019-0735)
+
+Notable Changes:
+
+* deps: Upgrade to OpenSSL 1.1.0j, fixing CVE-2018-0734 and CVE-2019-0735
+* http:
+  * Headers received by HTTP servers must not exceed 8192 bytes in total to
+    prevent possible Denial of Service attacks. Reported by Trevor Norris.
+    (CVE-2018-12121 / Matteo Collina)
+  * A timeout of 40 seconds now applies to servers receiving HTTP headers. This
+    value can be adjusted with `server.headersTimeout`. Where headers are not
+    completely received within this period, the socket is destroyed on the next
+    received chunk. In conjunction with `server.setTimeout()`, this aids in
+    protecting against excessive resource retention and possible Denial of
+    Service. Reported by Jan Maybach (liebdich.com).
+* url: Fix a bug that would allow a hostname being spoofed when parsing URLs
+  with `url.parse()` with the `&amp;#39;javascript:&amp;#39;` protocol. Reported by
+  Martin Bajanik (kenticocloud.com). (CVE-2018-12123 / Matteo Collina)
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/155/&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/8b1405ee014033d9a36873f65ca49be11f15a569</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/8b1405ee014033d9a36873f65ca49be11f15a569"/>
+    <title>
+        url: avoid hostname spoofing w/ javascript protocol
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;url: avoid hostname spoofing w/ javascript protocol
+
+CVE-2018-12123
+
+Fixes: https://github.com/nodejs-private/security/issues/205
+PR-URL: https://github.com/nodejs-private/node-private/pull/145
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/eb43bc04b1390ce2506144b46d081e63f7a7d5b7</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/eb43bc04b1390ce2506144b46d081e63f7a7d5b7"/>
+    <title>
+        http,https: protect against slow headers attack
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;http,https: protect against slow headers attack
+
+CVE-2018-12122
+
+An attacker can send a char/s within headers and exahust the resources
+(file descriptors) of a system even with a tight max header length
+protection. This PR destroys a socket if it has not received the headers
+in 40s.
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/150
+Ref: https://github.com/nodejs-private/node-private/pull/144
+Reviewed-By: Sam Roberts &amp;lt;vieuxtech@gmail.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a8532d4d23304d8cc28c968e2eda519a546834ca</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/a8532d4d23304d8cc28c968e2eda519a546834ca"/>
+    <title>
+        deps,http: http_parser set max header size to 8KB
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps,http: http_parser set max header size to 8KB
+
+CVE-2018-12121
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/143
+Ref: https://github.com/nodejs-private/security/issues/139
+Ref: https://github.com/nodejs-private/http-parser-private/pull/2
+Reviewed-By: Anatoli Papirovski &amp;lt;apapirovski@mac.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/38ca8baf81a2caf05253718db6bf56e49543e8ef</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/38ca8baf81a2caf05253718db6bf56e49543e8ef"/>
+    <title>
+        deps: update openssl 1.1.0 upgrade docs
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update openssl 1.1.0 upgrade docs
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/241ba81a5b4805324e8acfd1781ed607278784ce</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/241ba81a5b4805324e8acfd1781ed607278784ce"/>
+    <title>
+        deps: update archs files for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update archs files for OpenSSL-1.1.0
+
+`cd deps/openssl/config; make` updates all archs dependant files.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/acc40efa905c73fb7475ca5008d65dbdcd5f4867</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/acc40efa905c73fb7475ca5008d65dbdcd5f4867"/>
+    <title>
+        deps: add s390 asm rules for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/782880?s=30&amp;v=4"/>
+    <author>
+      <name>shigeki</name>
+      <uri>https://github.com/shigeki</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: add s390 asm rules for OpenSSL-1.1.0
+
+This is a floating patch against OpenSSL-1.1.0 to generate asm files
+with Makefile rules and it is to be submitted to the upstream.
+
+Fixes: https://github.com/nodejs/node/issues/4270
+PR-URL: https://github.com/nodejs/node/pull/19794
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/7efd184bb16ecf1b93fe9a5b9300e2353149d330</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/7efd184bb16ecf1b93fe9a5b9300e2353149d330"/>
+    <title>
+        deps: upgrade openssl sources to 1.1.0j
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: upgrade openssl sources to 1.1.0j
+
+This updates all sources in deps/openssl/openssl with openssl-1.1.0j.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4febb6c767787dfb8c56d9c80812cd8a4baa53b6</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4febb6c767787dfb8c56d9c80812cd8a4baa53b6"/>
+    <title>
+        Working on v10.13.1
+    </title>
+    <updated>2018-10-30T08:42:12Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/498775?s=30&amp;v=4"/>
+    <author>
+      <name>MylesBorins</name>
+      <uri>https://github.com/MylesBorins</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v10.13.1
+
+PR-URL: https://github.com/nodejs/node/pull/23831&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/ab4af087e83d91a46354d765306d3543b1d85423</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/ab4af087e83d91a46354d765306d3543b1d85423"/>
+    <title>
+        2018-10-30 Version 10.13.0 &#39;Dubnium&#39; (LTS)
+    </title>
+    <updated>2018-10-30T06:20:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/498775?s=30&amp;v=4"/>
+    <author>
+      <name>MylesBorins</name>
+      <uri>https://github.com/MylesBorins</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-10-30 Version 10.13.0 &amp;#39;Dubnium&amp;#39; (LTS)
+
+This release marks the transition of Node.js 10.x into Long Term
+Support (LTS) with the codename &amp;#39;Dubnium&amp;#39;. The 10.x release line
+now moves in to &amp;quot;Active LTS&amp;quot; and will remain so until April 2020.
+After that time it will move in to &amp;quot;Maintenance&amp;quot; until end of
+life in April 2021.
+
+Notable Changes:
+
+This release only includes minimal changes necessary to fix known
+regressions prior to LTS.
+
+PR-URL: https://github.com/nodejs/node/pull/23831&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/2ba60100820afe9b01f0d3dcee46453ce26db7e0</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/2ba60100820afe9b01f0d3dcee46453ce26db7e0"/>
+    <title>
+        buffer: fix crash for invalid index types
+    </title>
+    <updated>2018-10-29T19:39:48Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/899444?s=30&amp;v=4"/>
+    <author>
+      <name>addaleax</name>
+      <uri>https://github.com/addaleax</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;buffer: fix crash for invalid index types
+
+2555cb4a4049dc4c41d8a2f4ce50909cc0a12a4a introduced a crash
+when a non-number value was passed to `ParseArrayIndex()`.
+
+We do not always have JS typechecking for that in place, though.
+This returns back to the previous behavior of coercing values
+to integers, which is certainly questionable.
+
+Refs: https://github.com/nodejs/node/pull/22129
+Fixes: https://github.com/nodejs/node/issues/23668&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/2cd68be69d7a60e8b419085e42a0cf7bfcd6ea2f</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/2cd68be69d7a60e8b419085e42a0cf7bfcd6ea2f"/>
+    <title>
+        build: spawn `make test-ci` with `-j1`
+    </title>
+    <updated>2018-10-29T19:39:48Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;build: spawn `make test-ci` with `-j1`
+
+All the sub targets have internal parallelism, so no performance loss.
+Also `make` doesn&amp;#39;t to a good enough job of combining the output
+streams, or eliminate races.
+
+PR-URL: https://github.com/nodejs/node/pull/23733
+Fixes: https://github.com/nodejs/node/issues/22006
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;
+Reviewed-By: Joyee Cheung &amp;lt;joyeec9h3@gmail.com&amp;gt;
+Reviewed-By: Matheus Marchini &amp;lt;mat@mmarchini.me&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/1003f4c97531cd3e44c635da83d0cbe7be8d6048</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/1003f4c97531cd3e44c635da83d0cbe7be8d6048"/>
+    <title>
+        deps: fix wrong default for v8 handle zapping
+    </title>
+    <updated>2018-10-25T15:53:25Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: fix wrong default for v8 handle zapping
+
+PR-URL: https://github.com/nodejs/node/pull/23801
+Fixes: https://github.com/nodejs/node/issues/23796
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Michaël Zasso &amp;lt;targos@protonmail.com&amp;gt;
+Reviewed-By: Matheus Marchini &amp;lt;mat@mmarchini.me&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b66f46cb023a09cc77957c9360ae2cf18c4db188</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/b66f46cb023a09cc77957c9360ae2cf18c4db188"/>
+    <title>
+        Working on v10.12.1
+    </title>
+    <updated>2018-10-10T21:13:29Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v10.12.1
+
+PR-URL: https://github.com/nodejs/node/pull/23313&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4a276cc2a960b3f9a138ac3a99c9249a63b4d472</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4a276cc2a960b3f9a138ac3a99c9249a63b4d472"/>
+    <title>
+        2018-10-10, Version 10.12.0 (Current)
+    </title>
+    <updated>2018-10-10T16:10:08Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-10-10, Version 10.12.0 (Current)
+
+Notable changes:
+
+* assert
+  * The diff output is now a tiny bit improved by sorting object
+    properties when inspecting the values that are compared with each
+    other. https://github.com/nodejs/node/pull/22788
+* cli
+  * The options parser now normalizes `_` to `-` in all multi-word
+    command-line flags, e.g. `--no_warnings` has the same effect as
+    `--no-warnings`. https://github.com/nodejs/node/pull/23020
+  * Added bash completion for the `node` binary. To generate a bash
+    completion script, run `node --completion-bash`. The output can be
+    saved to a file which can be sourced to enable completion.
+    https://github.com/nodejs/node/pull/20713
+* crypto
+  * Added support for PEM-level encryption.
+    https://github.com/nodejs/node/pull/23151
+  * Added an API asymmetric key pair generation. The new methods
+    `crypto.generateKeyPair` and `crypto.generateKeyPairSync` can be
+    used to generate public and private key pairs. The API supports
+    RSA, DSA and EC and a variety of key encodings (both PEM and DER).
+    https://github.com/nodejs/node/pull/22660
+* fs
+  * Added a `recursive` option to `fs.mkdir` and `fs.mkdirSync`. If
+    this option is set to true, non-existing parent folders will be
+    automatically created. https://github.com/nodejs/node/pull/21875
+* http2
+  * Added a `&amp;#39;ping&amp;#39;` event to `Http2Session` that is emitted whenever a
+    non-ack `PING` is received.
+    https://github.com/nodejs/node/pull/23009
+  * Added support for the `ORIGIN` frame.
+    https://github.com/nodejs/node/pull/22956
+  * Updated nghttp2 to 1.34.0. This adds RFC 8441 extended connect
+    protocol support to allow use of WebSockets over HTTP/2.
+    https://github.com/nodejs/node/pull/23284
+* module
+  * Added `module.createRequireFromPath(filename)`. This new method can
+    be used to create a custom require function that will resolve
+    modules relative to the filename path.
+    https://github.com/nodejs/node/pull/19360
+* process
+  * Added a `&amp;#39;multipleResolves&amp;#39;` process event that is emitted whenever
+    a `Promise` is attempted to be resolved multiple times, e.g. if the
+    `resolve` and `reject` functions are both called in a `Promise`
+    executor. https://github.com/nodejs/node/pull/22218
+* url
+  * Added `url.fileURLToPath(url)` and `url.pathToFileURL(path)`. These
+    methods can be used to correctly convert between file: URLs and
+    absolute paths. https://github.com/nodejs/node/pull/22506
+* util
+  * Added the `sorted` option to `util.inspect()`. If set to `true`,
+    all properties of an object and Set and Map entries will be sorted
+    in the returned string. If set to a function, it is used as a
+    compare function. https://github.com/nodejs/node/pull/22788
+  * The `util.instpect.custom` symbol is now defined in the global
+    symbol registry as `Symbol.for(&amp;#39;nodejs.util.inspect.custom&amp;#39;)`.
+    https://github.com/nodejs/node/pull/20857
+  * Added support for `BigInt` numbers in `util.format()`.
+    https://github.com/nodejs/node/pull/22097
+* V8 API
+  * A number of V8 C++ APIs have been marked as deprecated since they
+    have been removed in the upstream repository. Replacement APIs
+    are added where necessary. https://github.com/nodejs/node/pull/23159
+* Windows
+  * The Windows msi installer now provides an option to automatically
+    install the tools required to build native modules.
+    https://github.com/nodejs/node/pull/22645
+* Workers
+  * Debugging support for Workers using the DevTools protocol has been
+    implemented. https://github.com/nodejs/node/pull/21364
+  * The public `inspector` module is now enabled in Workers.
+    https://github.com/nodejs/node/pull/22769
+* Added new collaborators:
+  * digitalinfinity - Hitesh Kanwathirtha
+
+PR-URL: https://github.com/nodejs/node/pull/23313&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/e6484c2c1193d8067e01477497b7dfbb4d8ccab3</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/e6484c2c1193d8067e01477497b7dfbb4d8ccab3"/>
+    <title>
+        build: restore js2c direct dependency on config.gypi
+    </title>
+    <updated>2018-10-10T15:40:21Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;build: restore js2c direct dependency on config.gypi
+
+PR-URL: https://github.com/nodejs/node/pull/23355
+Fixes: https://github.com/nodejs/node/issues/23352
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Joyee Cheung &amp;lt;joyeec9h3@gmail.com&amp;gt;
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/cd69e1b6c3e07946b53548b72228c432e2993a79</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/cd69e1b6c3e07946b53548b72228c432e2993a79"/>
+    <title>
+        src: fix ToObject() usage in node_http_parser.cc
+    </title>
+    <updated>2018-10-10T15:40:21Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2512748?s=30&amp;v=4"/>
+    <author>
+      <name>cjihrig</name>
+      <uri>https://github.com/cjihrig</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;src: fix ToObject() usage in node_http_parser.cc
+
+PR-URL: https://github.com/nodejs/node/pull/23314
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Sakthipriyan Vairamani &amp;lt;thechargingvolcano@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/5228ec4410605651192137890da5c41ac5755bcc</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/5228ec4410605651192137890da5c41ac5755bcc"/>
+    <title>
+        src: fix ToObject() usage in exceptions.cc
+    </title>
+    <updated>2018-10-10T15:40:21Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2512748?s=30&amp;v=4"/>
+    <author>
+      <name>cjihrig</name>
+      <uri>https://github.com/cjihrig</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;src: fix ToObject() usage in exceptions.cc
+
+PR-URL: https://github.com/nodejs/node/pull/23314
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Sakthipriyan Vairamani &amp;lt;thechargingvolcano@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/c4aa0331c108f55c5a56193fac0249a27767de03</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/c4aa0331c108f55c5a56193fac0249a27767de03"/>
+    <title>
+        build: make configure script verbose by default
+    </title>
+    <updated>2018-10-10T15:37:07Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;build: make configure script verbose by default
+
+The change that added the --verbose flag was supposed to be
+semver-major but already landed in a 10.x release.
+
+Refs: https://github.com/nodejs/node/pull/22450
+
+PR-URL: https://github.com/nodejs/node/pull/23408
+Reviewed-By: Colin Ihrig &amp;lt;cjihrig@gmail.com&amp;gt;
+Reviewed-By: Rich Trott &amp;lt;rtrott@gmail.com&amp;gt;
+Reviewed-By: Refael Ackermann &amp;lt;refack@gmail.com&amp;gt;
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;
+Reviewed-By: Sakthipriyan Vairamani &amp;lt;thechargingvolcano@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a65bb42551b635b3bb948ab1c9f7064da1b77554</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/a65bb42551b635b3bb948ab1c9f7064da1b77554"/>
+    <title>
+        net: use connect() instead of connect.call()
+    </title>
+    <updated>2018-10-10T13:42:52Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/327019?s=30&amp;v=4"/>
+    <author>
+      <name>JacksonTian</name>
+      <uri>https://github.com/JacksonTian</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;net: use connect() instead of connect.call()
+
+Use socket.connect() directly.
+
+PR-URL: https://github.com/nodejs/node/pull/23289
+Reviewed-By: Luigi Pinca &amp;lt;luigipinca@gmail.com&amp;gt;
+Reviewed-By: Sakthipriyan Vairamani &amp;lt;thechargingvolcano@gmail.com&amp;gt;
+Reviewed-By: Trivikram Kamat &amp;lt;trivikr.dev@gmail.com&amp;gt;
+Reviewed-By: Colin Ihrig &amp;lt;cjihrig@gmail.com&amp;gt;
+Reviewed-By: Thomas Watson &amp;lt;w@tson.dk&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+</feed>

--- a/test/fixtures/release-notes/v10.14.1.atom
+++ b/test/fixtures/release-notes/v10.14.1.atom
@@ -1,0 +1,608 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:/nodejs/node/commits/v10.14.1</id>
+  <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commits/v10.14.1"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/nodejs/node/commits/v10.14.1.atom"/>
+  <title>Recent Commits to node:v10.14.1</title>
+  <updated>2018-11-29T04:47:06Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/d3dbe3a8514e47ef820d4768ed74c36a8843b976</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/d3dbe3a8514e47ef820d4768ed74c36a8843b976"/>
+    <title>
+        2018-11-29, Version 10.14.1 &#39;Dubnium&#39; (LTS)
+    </title>
+    <updated>2018-11-29T04:47:06Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/498775?s=30&amp;v=4"/>
+    <author>
+      <name>MylesBorins</name>
+      <uri>https://github.com/MylesBorins</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-11-29, Version 10.14.1 &amp;#39;Dubnium&amp;#39; (LTS)
+
+Notable Changes:
+
+* **win/msi**: Revert changes to installer causing issues on Windows systems.
+
+PR-URL: https://github.com/nodejs/node/pull/24711&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/9e293c13288a0fa3da20b7ccf4421a6d0b413bb2</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/9e293c13288a0fa3da20b7ccf4421a6d0b413bb2"/>
+    <title>
+        Revert &quot;win,msi: install tools for native modules&quot;
+    </title>
+    <updated>2018-11-29T04:39:31Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Revert &amp;quot;win,msi: install tools for native modules&amp;quot;
+
+This reverts:
+	Revision: 257a5e9c389b648aca08b02aae9e19f142ce0493
+	win: add prompt to tools installation script
+
+	Revision: e9a291582d145a00df27aaaa54b66e42c725d89e
+	win: clarify Boxstarter behavior on install tools
+
+	Revision: 3b895d12584a91acf3866a728ed490841490dc95
+	win,msi: display license notes before installing tools
+
+	Revision: cf284c80a9c82d4baebf095c356179c753da493c
+	win,msi: install Boxstarter from elevated shell
+
+	Revision: 2b7e18dec5ccb51270df7c8bd554ffdf2e28e603
+	win,msi: highlight installation of 3rd-party tools
+
+	Revision: ebf36cd18018faab5427327c3469a71dd1d35129
+	win,msi: install tools for native modules
+
+PR-URL: https://github.com/nodejs/node/pull/24344
+Refs: https://github.com/nodejs/node/pull/22645
+Refs: https://github.com/nodejs/node/pull/23987
+Refs: https://github.com/nodejs/Release/issues/369
+Refs: https://github.com/nodejs/node/issues/23838
+Refs: https://github.com/nodejs/security-wg/issues/439
+Reviewed-By: João Reis &amp;lt;reis@janeasystems.com&amp;gt;
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/5d17bf1e1386b17d81efc3e9e14f185e8d442b4a</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/5d17bf1e1386b17d81efc3e9e14f185e8d442b4a"/>
+    <title>
+        win: add prompt to tools installation script
+    </title>
+    <updated>2018-11-29T04:39:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/134460?s=30&amp;v=4"/>
+    <author>
+      <name>joaocgreis</name>
+      <uri>https://github.com/joaocgreis</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;win: add prompt to tools installation script
+
+Fixes: https://github.com/nodejs/Release/issues/369
+
+PR-URL: https://github.com/nodejs/node/pull/23987
+Reviewed-By: John-David Dalton &amp;lt;john.david.dalton@gmail.com&amp;gt;
+Reviewed-By: Refael Ackermann &amp;lt;refack@gmail.com&amp;gt;
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/589f0d2192210eb1a455d7cdbe7d1a668d1f8843</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/589f0d2192210eb1a455d7cdbe7d1a668d1f8843"/>
+    <title>
+        win: clarify Boxstarter behavior on install tools
+    </title>
+    <updated>2018-11-29T04:39:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/63502?s=30&amp;v=4"/>
+    <author>
+      <name>ferventcoder</name>
+      <uri>https://github.com/ferventcoder</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;win: clarify Boxstarter behavior on install tools
+
+Clarify the behavior of what Boxstarter may do when it runs on a box
+to install all the necessary tools so that there are no surprises to
+the end user when the script is run.
+
+Currently there is no interface that warns the user that Boxstarter
+will reboot the machine possibly multiple times depending on how many
+dependencies need to be installed and doesn&amp;#39;t mention a need to disable
+UAC. For folks who see what may look like a reboot loop, we feel it is
+necessary to make them aware that UAC will be disabled and they will
+need to take action to re-enable UAC manually if they interfere/stop
+the script from finishing.
+
+PR-URL: https://github.com/nodejs/node/pull/23987
+Fixes: https://github.com/nodejs/Release/issues/369
+Reviewed-By: John-David Dalton &amp;lt;john.david.dalton@gmail.com&amp;gt;
+Reviewed-By: Refael Ackermann &amp;lt;refack@gmail.com&amp;gt;
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/183e3bf1b0ddc0c0072bb1bc63ec06b77bd4aa07</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/183e3bf1b0ddc0c0072bb1bc63ec06b77bd4aa07"/>
+    <title>
+        Working on v10.14.1
+    </title>
+    <updated>2018-11-28T00:14:05Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v10.14.1
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/155/&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b7103135bc7987dee97e8795b0b38293d05fd842</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/b7103135bc7987dee97e8795b0b38293d05fd842"/>
+    <title>
+        2018-11-27, Version 10.14.0 &#39;Dubnium&#39; (LTS)
+    </title>
+    <updated>2018-11-27T22:17:04Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-11-27, Version 10.14.0 &amp;#39;Dubnium&amp;#39; (LTS)
+
+This is a security release. All Node.js users should consult the security
+release summary at:
+
+  https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/
+
+for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+  * Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+  * Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+  * Node.js: Hostname spoofing in URL parser for javascript protocol
+    (CVE-2018-12123)
+  * OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+  * OpenSSL: Timing vulnerability in ECDSA signature generation (CVE-2019-0735)
+
+Notable Changes:
+
+* deps: Upgrade to OpenSSL 1.1.0j, fixing CVE-2018-0734 and CVE-2019-0735
+* http:
+  * Headers received by HTTP servers must not exceed 8192 bytes in total to
+    prevent possible Denial of Service attacks. Reported by Trevor Norris.
+    (CVE-2018-12121 / Matteo Collina)
+  * A timeout of 40 seconds now applies to servers receiving HTTP headers. This
+    value can be adjusted with `server.headersTimeout`. Where headers are not
+    completely received within this period, the socket is destroyed on the next
+    received chunk. In conjunction with `server.setTimeout()`, this aids in
+    protecting against excessive resource retention and possible Denial of
+    Service. Reported by Jan Maybach (liebdich.com).
+* url: Fix a bug that would allow a hostname being spoofed when parsing URLs
+  with `url.parse()` with the `&amp;#39;javascript:&amp;#39;` protocol. Reported by
+  Martin Bajanik (kenticocloud.com). (CVE-2018-12123 / Matteo Collina)
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/155/&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/8b1405ee014033d9a36873f65ca49be11f15a569</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/8b1405ee014033d9a36873f65ca49be11f15a569"/>
+    <title>
+        url: avoid hostname spoofing w/ javascript protocol
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;url: avoid hostname spoofing w/ javascript protocol
+
+CVE-2018-12123
+
+Fixes: https://github.com/nodejs-private/security/issues/205
+PR-URL: https://github.com/nodejs-private/node-private/pull/145
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/eb43bc04b1390ce2506144b46d081e63f7a7d5b7</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/eb43bc04b1390ce2506144b46d081e63f7a7d5b7"/>
+    <title>
+        http,https: protect against slow headers attack
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;http,https: protect against slow headers attack
+
+CVE-2018-12122
+
+An attacker can send a char/s within headers and exahust the resources
+(file descriptors) of a system even with a tight max header length
+protection. This PR destroys a socket if it has not received the headers
+in 40s.
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/150
+Ref: https://github.com/nodejs-private/node-private/pull/144
+Reviewed-By: Sam Roberts &amp;lt;vieuxtech@gmail.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a8532d4d23304d8cc28c968e2eda519a546834ca</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/a8532d4d23304d8cc28c968e2eda519a546834ca"/>
+    <title>
+        deps,http: http_parser set max header size to 8KB
+    </title>
+    <updated>2018-11-27T04:11:44Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps,http: http_parser set max header size to 8KB
+
+CVE-2018-12121
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/143
+Ref: https://github.com/nodejs-private/security/issues/139
+Ref: https://github.com/nodejs-private/http-parser-private/pull/2
+Reviewed-By: Anatoli Papirovski &amp;lt;apapirovski@mac.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/38ca8baf81a2caf05253718db6bf56e49543e8ef</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/38ca8baf81a2caf05253718db6bf56e49543e8ef"/>
+    <title>
+        deps: update openssl 1.1.0 upgrade docs
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update openssl 1.1.0 upgrade docs
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/241ba81a5b4805324e8acfd1781ed607278784ce</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/241ba81a5b4805324e8acfd1781ed607278784ce"/>
+    <title>
+        deps: update archs files for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update archs files for OpenSSL-1.1.0
+
+`cd deps/openssl/config; make` updates all archs dependant files.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/acc40efa905c73fb7475ca5008d65dbdcd5f4867</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/acc40efa905c73fb7475ca5008d65dbdcd5f4867"/>
+    <title>
+        deps: add s390 asm rules for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/782880?s=30&amp;v=4"/>
+    <author>
+      <name>shigeki</name>
+      <uri>https://github.com/shigeki</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: add s390 asm rules for OpenSSL-1.1.0
+
+This is a floating patch against OpenSSL-1.1.0 to generate asm files
+with Makefile rules and it is to be submitted to the upstream.
+
+Fixes: https://github.com/nodejs/node/issues/4270
+PR-URL: https://github.com/nodejs/node/pull/19794
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/7efd184bb16ecf1b93fe9a5b9300e2353149d330</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/7efd184bb16ecf1b93fe9a5b9300e2353149d330"/>
+    <title>
+        deps: upgrade openssl sources to 1.1.0j
+    </title>
+    <updated>2018-11-24T10:42:20Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: upgrade openssl sources to 1.1.0j
+
+This updates all sources in deps/openssl/openssl with openssl-1.1.0j.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4febb6c767787dfb8c56d9c80812cd8a4baa53b6</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4febb6c767787dfb8c56d9c80812cd8a4baa53b6"/>
+    <title>
+        Working on v10.13.1
+    </title>
+    <updated>2018-10-30T08:42:12Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/498775?s=30&amp;v=4"/>
+    <author>
+      <name>MylesBorins</name>
+      <uri>https://github.com/MylesBorins</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v10.13.1
+
+PR-URL: https://github.com/nodejs/node/pull/23831&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/ab4af087e83d91a46354d765306d3543b1d85423</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/ab4af087e83d91a46354d765306d3543b1d85423"/>
+    <title>
+        2018-10-30 Version 10.13.0 &#39;Dubnium&#39; (LTS)
+    </title>
+    <updated>2018-10-30T06:20:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/498775?s=30&amp;v=4"/>
+    <author>
+      <name>MylesBorins</name>
+      <uri>https://github.com/MylesBorins</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-10-30 Version 10.13.0 &amp;#39;Dubnium&amp;#39; (LTS)
+
+This release marks the transition of Node.js 10.x into Long Term
+Support (LTS) with the codename &amp;#39;Dubnium&amp;#39;. The 10.x release line
+now moves in to &amp;quot;Active LTS&amp;quot; and will remain so until April 2020.
+After that time it will move in to &amp;quot;Maintenance&amp;quot; until end of
+life in April 2021.
+
+Notable Changes:
+
+This release only includes minimal changes necessary to fix known
+regressions prior to LTS.
+
+PR-URL: https://github.com/nodejs/node/pull/23831&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/2ba60100820afe9b01f0d3dcee46453ce26db7e0</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/2ba60100820afe9b01f0d3dcee46453ce26db7e0"/>
+    <title>
+        buffer: fix crash for invalid index types
+    </title>
+    <updated>2018-10-29T19:39:48Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/899444?s=30&amp;v=4"/>
+    <author>
+      <name>addaleax</name>
+      <uri>https://github.com/addaleax</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;buffer: fix crash for invalid index types
+
+2555cb4a4049dc4c41d8a2f4ce50909cc0a12a4a introduced a crash
+when a non-number value was passed to `ParseArrayIndex()`.
+
+We do not always have JS typechecking for that in place, though.
+This returns back to the previous behavior of coercing values
+to integers, which is certainly questionable.
+
+Refs: https://github.com/nodejs/node/pull/22129
+Fixes: https://github.com/nodejs/node/issues/23668&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/2cd68be69d7a60e8b419085e42a0cf7bfcd6ea2f</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/2cd68be69d7a60e8b419085e42a0cf7bfcd6ea2f"/>
+    <title>
+        build: spawn `make test-ci` with `-j1`
+    </title>
+    <updated>2018-10-29T19:39:48Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;build: spawn `make test-ci` with `-j1`
+
+All the sub targets have internal parallelism, so no performance loss.
+Also `make` doesn&amp;#39;t to a good enough job of combining the output
+streams, or eliminate races.
+
+PR-URL: https://github.com/nodejs/node/pull/23733
+Fixes: https://github.com/nodejs/node/issues/22006
+Reviewed-By: Richard Lau &amp;lt;riclau@uk.ibm.com&amp;gt;
+Reviewed-By: Joyee Cheung &amp;lt;joyeec9h3@gmail.com&amp;gt;
+Reviewed-By: Matheus Marchini &amp;lt;mat@mmarchini.me&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/1003f4c97531cd3e44c635da83d0cbe7be8d6048</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/1003f4c97531cd3e44c635da83d0cbe7be8d6048"/>
+    <title>
+        deps: fix wrong default for v8 handle zapping
+    </title>
+    <updated>2018-10-25T15:53:25Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/96947?s=30&amp;v=4"/>
+    <author>
+      <name>refack</name>
+      <uri>https://github.com/refack</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: fix wrong default for v8 handle zapping
+
+PR-URL: https://github.com/nodejs/node/pull/23801
+Fixes: https://github.com/nodejs/node/issues/23796
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Michaël Zasso &amp;lt;targos@protonmail.com&amp;gt;
+Reviewed-By: Matheus Marchini &amp;lt;mat@mmarchini.me&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b66f46cb023a09cc77957c9360ae2cf18c4db188</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/b66f46cb023a09cc77957c9360ae2cf18c4db188"/>
+    <title>
+        Working on v10.12.1
+    </title>
+    <updated>2018-10-10T21:13:29Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v10.12.1
+
+PR-URL: https://github.com/nodejs/node/pull/23313&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4a276cc2a960b3f9a138ac3a99c9249a63b4d472</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4a276cc2a960b3f9a138ac3a99c9249a63b4d472"/>
+    <title>
+        2018-10-10, Version 10.12.0 (Current)
+    </title>
+    <updated>2018-10-10T16:10:08Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-10-10, Version 10.12.0 (Current)
+
+Notable changes:
+
+* assert
+  * The diff output is now a tiny bit improved by sorting object
+    properties when inspecting the values that are compared with each
+    other. https://github.com/nodejs/node/pull/22788
+* cli
+  * The options parser now normalizes `_` to `-` in all multi-word
+    command-line flags, e.g. `--no_warnings` has the same effect as
+    `--no-warnings`. https://github.com/nodejs/node/pull/23020
+  * Added bash completion for the `node` binary. To generate a bash
+    completion script, run `node --completion-bash`. The output can be
+    saved to a file which can be sourced to enable completion.
+    https://github.com/nodejs/node/pull/20713
+* crypto
+  * Added support for PEM-level encryption.
+    https://github.com/nodejs/node/pull/23151
+  * Added an API asymmetric key pair generation. The new methods
+    `crypto.generateKeyPair` and `crypto.generateKeyPairSync` can be
+    used to generate public and private key pairs. The API supports
+    RSA, DSA and EC and a variety of key encodings (both PEM and DER).
+    https://github.com/nodejs/node/pull/22660
+* fs
+  * Added a `recursive` option to `fs.mkdir` and `fs.mkdirSync`. If
+    this option is set to true, non-existing parent folders will be
+    automatically created. https://github.com/nodejs/node/pull/21875
+* http2
+  * Added a `&amp;#39;ping&amp;#39;` event to `Http2Session` that is emitted whenever a
+    non-ack `PING` is received.
+    https://github.com/nodejs/node/pull/23009
+  * Added support for the `ORIGIN` frame.
+    https://github.com/nodejs/node/pull/22956
+  * Updated nghttp2 to 1.34.0. This adds RFC 8441 extended connect
+    protocol support to allow use of WebSockets over HTTP/2.
+    https://github.com/nodejs/node/pull/23284
+* module
+  * Added `module.createRequireFromPath(filename)`. This new method can
+    be used to create a custom require function that will resolve
+    modules relative to the filename path.
+    https://github.com/nodejs/node/pull/19360
+* process
+  * Added a `&amp;#39;multipleResolves&amp;#39;` process event that is emitted whenever
+    a `Promise` is attempted to be resolved multiple times, e.g. if the
+    `resolve` and `reject` functions are both called in a `Promise`
+    executor. https://github.com/nodejs/node/pull/22218
+* url
+  * Added `url.fileURLToPath(url)` and `url.pathToFileURL(path)`. These
+    methods can be used to correctly convert between file: URLs and
+    absolute paths. https://github.com/nodejs/node/pull/22506
+* util
+  * Added the `sorted` option to `util.inspect()`. If set to `true`,
+    all properties of an object and Set and Map entries will be sorted
+    in the returned string. If set to a function, it is used as a
+    compare function. https://github.com/nodejs/node/pull/22788
+  * The `util.instpect.custom` symbol is now defined in the global
+    symbol registry as `Symbol.for(&amp;#39;nodejs.util.inspect.custom&amp;#39;)`.
+    https://github.com/nodejs/node/pull/20857
+  * Added support for `BigInt` numbers in `util.format()`.
+    https://github.com/nodejs/node/pull/22097
+* V8 API
+  * A number of V8 C++ APIs have been marked as deprecated since they
+    have been removed in the upstream repository. Replacement APIs
+    are added where necessary. https://github.com/nodejs/node/pull/23159
+* Windows
+  * The Windows msi installer now provides an option to automatically
+    install the tools required to build native modules.
+    https://github.com/nodejs/node/pull/22645
+* Workers
+  * Debugging support for Workers using the DevTools protocol has been
+    implemented. https://github.com/nodejs/node/pull/21364
+  * The public `inspector` module is now enabled in Workers.
+    https://github.com/nodejs/node/pull/22769
+* Added new collaborators:
+  * digitalinfinity - Hitesh Kanwathirtha
+
+PR-URL: https://github.com/nodejs/node/pull/23313&lt;/pre&gt;
+    </content>
+  </entry>
+</feed>

--- a/test/fixtures/release-notes/v11.3.0.atom
+++ b/test/fixtures/release-notes/v11.3.0.atom
@@ -1,0 +1,544 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:/nodejs/node/commits/v11.3.0</id>
+  <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commits/v11.3.0"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/nodejs/node/commits/v11.3.0.atom"/>
+  <title>Recent Commits to node:v11.3.0</title>
+  <updated>2018-11-27T04:36:42Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/00fb73a72eff0e90d0f85b95dbcfc3c21f89cff9</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/00fb73a72eff0e90d0f85b95dbcfc3c21f89cff9"/>
+    <title>
+        2018-11-27, Version 11.3.0 (Current)
+    </title>
+    <updated>2018-11-27T04:36:42Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-11-27, Version 11.3.0 (Current)
+
+This is a security release. All Node.js users should consult the security
+release summary at:
+
+https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/
+
+for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+  * Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+  * Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+  * Node.js: Hostname spoofing in URL parser for javascript protocol
+    (CVE-2018-12123)
+  * OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+  * OpenSSL: Timing vulnerability in ECDSA signature generation (CVE-2019-0735)
+
+Notable Changes:
+
+* deps: Upgrade to OpenSSL 1.1.0j, fixing CVE-2018-0734 and CVE-2019-0735
+* http:
+  * Headers received by HTTP servers must not exceed 8192 bytes in total to
+    prevent possible Denial of Service attacks. Reported by Trevor Norris.
+    (CVE-2018-12121 / Matteo Collina)
+  * A timeout of 40 seconds now applies to servers receiving HTTP headers. This
+    value can be adjusted with `server.headersTimeout`. Where headers are not
+    completely received within this period, the socket is destroyed on the next
+    received chunk. In conjunction with `server.setTimeout()`, this aids in
+    protecting against excessive resource retention and possible Denial of
+    Service. Reported by Jan Maybach (liebdich.com).
+* url: Fix a bug that would allow a hostname being spoofed when parsing URLs
+  with `url.parse()` with the `&amp;#39;javascript:&amp;#39;` protocol. Reported by
+  Martin Bajanik (kenticocloud.com). (CVE-2018-12123 / Matteo Collina)
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/156/&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/d7504324e1dfc0ac3c6849c2913ee58faca6386a</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/d7504324e1dfc0ac3c6849c2913ee58faca6386a"/>
+    <title>
+        url: avoid hostname spoofing w/ javascript protocol
+    </title>
+    <updated>2018-11-27T04:30:17Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;url: avoid hostname spoofing w/ javascript protocol
+
+CVE-2018-12123
+
+Fixes: https://github.com/nodejs-private/security/issues/205
+PR-URL: https://github.com/nodejs-private/node-private/pull/145
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/315ee2e626f6134f372d8034d9b94b73717705c7</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/315ee2e626f6134f372d8034d9b94b73717705c7"/>
+    <title>
+        http,https: protect against slow headers attack
+    </title>
+    <updated>2018-11-27T04:30:17Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;http,https: protect against slow headers attack
+
+CVE-2018-12122
+
+An attacker can send a char/s within headers and exahust the resources
+(file descriptors) of a system even with a tight max header length
+protection. This PR destroys a socket if it has not received the headers
+in 40s.
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/144
+Reviewed-By: Sam Roberts &amp;lt;vieuxtech@gmail.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4ecbd3bdaad94c33a03bf390462706ce1952c2c7</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4ecbd3bdaad94c33a03bf390462706ce1952c2c7"/>
+    <title>
+        http: reset headers_nread_ on llhttp parser reuse
+    </title>
+    <updated>2018-11-27T04:29:40Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;http: reset headers_nread_ on llhttp parser reuse
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/149
+Reviewed-By: Fedor Indutny &amp;lt;fedor@indutny.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/04e0620597c30d19a0b4fd4ed04337619d49fb43</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/04e0620597c30d19a0b4fd4ed04337619d49fb43"/>
+    <title>
+        http: fix header limit errors and test for llhttp
+    </title>
+    <updated>2018-11-27T04:24:30Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/238531?s=30&amp;v=4"/>
+    <author>
+      <name>indutny</name>
+      <uri>https://github.com/indutny</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;http: fix header limit errors and test for llhttp
+
+Ref: https://github.com/nodejs-private/node-private/pull/143
+PR-URL: https://github.com/nodejs-private/node-private/pull/149
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a2b8aba23cffe392495736da373baf506f88da52</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/a2b8aba23cffe392495736da373baf506f88da52"/>
+    <title>
+        deps,http: llhttp set max header size to 8KB
+    </title>
+    <updated>2018-11-27T04:24:30Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/495647?s=30&amp;v=4"/>
+    <author>
+      <name>rvagg</name>
+      <uri>https://github.com/rvagg</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps,http: llhttp set max header size to 8KB
+
+CVE-2018-12121
+
+As per nodejs-private/node-private#149 for http_parse but for llhttp
+
+Ref: https://github.com/nodejs-private/node-private/pull/143
+PR-URL: https://github.com/nodejs-private/node-private/pull/149
+Reviewed-By: Matteo Collina &amp;lt;hello@matteocollina.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/74e01d0020ec255673e17353a1004a8ea375fff4</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/74e01d0020ec255673e17353a1004a8ea375fff4"/>
+    <title>
+        deps,http: http_parser set max header size to 8KB
+    </title>
+    <updated>2018-11-27T04:24:30Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars1.githubusercontent.com/u/52195?s=30&amp;v=4"/>
+    <author>
+      <name>mcollina</name>
+      <uri>https://github.com/mcollina</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps,http: http_parser set max header size to 8KB
+
+CVE-2018-12121
+
+PR-URL: https://github.com/nodejs-private/node-private/pull/143
+Ref: https://github.com/nodejs-private/security/issues/139
+Ref: https://github.com/nodejs-private/http-parser-private/pull/2
+Reviewed-By: Anatoli Papirovski &amp;lt;apapirovski@mac.com&amp;gt;
+Reviewed-By: Ben Noordhuis &amp;lt;info@bnoordhuis.nl&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/8f191f37596333ce4e7f9de8a8d839a576c9ca9f</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/8f191f37596333ce4e7f9de8a8d839a576c9ca9f"/>
+    <title>
+        deps: update openssl 1.1.0 upgrade docs
+    </title>
+    <updated>2018-11-25T09:49:51Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update openssl 1.1.0 upgrade docs
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/f20ac47d7a5738a43aa0726c1cd8d2873cfc7423</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/f20ac47d7a5738a43aa0726c1cd8d2873cfc7423"/>
+    <title>
+        deps: update archs files for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-25T09:49:51Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: update archs files for OpenSSL-1.1.0
+
+`cd deps/openssl/config; make` updates all archs dependant files.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/8248d227b76fc3c4bdf0abf91446b375202dc745</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/8248d227b76fc3c4bdf0abf91446b375202dc745"/>
+    <title>
+        deps: add s390 asm rules for OpenSSL-1.1.0
+    </title>
+    <updated>2018-11-25T09:49:51Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/782880?s=30&amp;v=4"/>
+    <author>
+      <name>shigeki</name>
+      <uri>https://github.com/shigeki</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: add s390 asm rules for OpenSSL-1.1.0
+
+This is a floating patch against OpenSSL-1.1.0 to generate asm files
+with Makefile rules and it is to be submitted to the upstream.
+
+Fixes: https://github.com/nodejs/node/issues/4270
+PR-URL: https://github.com/nodejs/node/pull/19794
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;
+Reviewed-By: Michael Dawson &amp;lt;michael_dawson@ca.ibm.com&amp;gt;
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/65d03f018008d28279c85e5a78712ad35930368a</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/65d03f018008d28279c85e5a78712ad35930368a"/>
+    <title>
+        deps: upgrade openssl sources to 1.1.0j
+    </title>
+    <updated>2018-11-25T09:49:51Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/17607?s=30&amp;v=4"/>
+    <author>
+      <name>sam-github</name>
+      <uri>https://github.com/sam-github</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;deps: upgrade openssl sources to 1.1.0j
+
+This updates all sources in deps/openssl/openssl with openssl-1.1.0j.
+
+PR-URL: https://github.com/nodejs/node/pull/24523
+Reviewed-By: Shigeki Ohtsu &amp;lt;ohtsu@ohtsu.org&amp;gt;
+Reviewed-By: Daniel Bevenius &amp;lt;daniel.bevenius@gmail.com&amp;gt;
+Reviewed-By: Rod Vagg &amp;lt;rod@vagg.org&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/fbe63ab15b68f3ebf07891e3014f7a0138bd323e</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/fbe63ab15b68f3ebf07891e3014f7a0138bd323e"/>
+    <title>
+        Working on v11.2.1
+    </title>
+    <updated>2018-11-15T21:13:13Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/2352663?s=30&amp;v=4"/>
+    <author>
+      <name>targos</name>
+      <uri>https://github.com/targos</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Working on v11.2.1
+
+PR-URL: https://github.com/nodejs/node/pull/24350&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a19e1aba38d4bd761b892b7384c457c6377e942c</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/a19e1aba38d4bd761b892b7384c457c6377e942c"/>
+    <title>
+        2018-11-15, Version 11.2.0 (Current)
+    </title>
+    <updated>2018-11-15T19:20:37Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/8822573?s=30&amp;v=4"/>
+    <author>
+      <name>BridgeAR</name>
+      <uri>https://github.com/BridgeAR</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;2018-11-15, Version 11.2.0 (Current)
+
+Notable changes:
+
+* deps:
+  * A new experimental HTTP parser (`llhttp`) is now supported.
+    https://github.com/nodejs/node/pull/24059
+* timers:
+  * Fixed an issue that could cause setTimeout to stop working as
+    expected. https://github.com/nodejs/node/pull/24322
+* Windows
+  * A crashing process will now show the names of stack frames if the
+    node.pdb file is available.
+    https://github.com/nodejs/node/pull/23822
+  * Continued effort to improve the installer&amp;#39;s new stage that installs
+    native build tools.
+    https://github.com/nodejs/node/pull/23987,
+    https://github.com/nodejs/node/pull/24348
+  * child_process:
+    * On Windows the `windowsHide` option default was restored to
+      `false`. This means `detached` child processes and GUI apps will
+      once again start in a new window.
+      https://github.com/nodejs/node/pull/24034
+* Added new collaborators:
+  * [oyyd](https://github.com/oyyd) - Ouyang Yadong.
+    https://github.com/nodejs/node/pull/24300
+  * [psmarshall](https://github.com/psmarshall) - Peter Marshall.
+    https://github.com/nodejs/node/pull/24170
+  * [shisama](https://github.com/shisama) - Masashi Hirano.
+    https://github.com/nodejs/node/pull/24136&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/10edc4f186f7b837708df1e805071fd923c382f0</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/10edc4f186f7b837708df1e805071fd923c382f0"/>
+    <title>
+        net: always invoke after-write callback
+    </title>
+    <updated>2018-11-15T17:56:05Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/899444?s=30&amp;v=4"/>
+    <author>
+      <name>addaleax</name>
+      <uri>https://github.com/addaleax</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;net: always invoke after-write callback
+
+This is part of the streams API contract, and aligns
+network sockets with other streams in this respect.
+
+PR-URL: https://github.com/nodejs/node/pull/24291
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Luigi Pinca &amp;lt;luigipinca@gmail.com&amp;gt;
+Reviewed-By: Benjamin Gruenbaum &amp;lt;benjamingr@gmail.com&amp;gt;
+Reviewed-By: Colin Ihrig &amp;lt;cjihrig@gmail.com&amp;gt;
+Reviewed-By: Weijia Wang &amp;lt;starkwang@126.com&amp;gt;
+Reviewed-By: Matteo Collina &amp;lt;matteo.collina@gmail.com&amp;gt;
+Reviewed-By: Ruben Bridgewater &amp;lt;ruben@bridgewater.de&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/eeb5cc63052c762b3058594d1ba29f739d35986f</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/eeb5cc63052c762b3058594d1ba29f739d35986f"/>
+    <title>
+        test: add typeerror for vm/compileFunction params
+    </title>
+    <updated>2018-11-15T17:56:05Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/10720586?s=30&amp;v=4"/>
+    <author>
+      <name>dYale</name>
+      <uri>https://github.com/dYale</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;test: add typeerror for vm/compileFunction params
+
+PR-URL: https://github.com/nodejs/node/pull/24179
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Joyee Cheung &amp;lt;joyeec9h3@gmail.com&amp;gt;
+Reviewed-By: Ruben Bridgewater &amp;lt;ruben@bridgewater.de&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/5ca0cf7ae6477eb207998083b90f74d7469c7d5d</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/5ca0cf7ae6477eb207998083b90f74d7469c7d5d"/>
+    <title>
+        lib: improved conditional check in zlib
+    </title>
+    <updated>2018-11-15T17:56:04Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars3.githubusercontent.com/u/10720586?s=30&amp;v=4"/>
+    <author>
+      <name>dYale</name>
+      <uri>https://github.com/dYale</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;lib: improved conditional check in zlib
+
+PR-URL: https://github.com/nodejs/node/pull/24190
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;
+Reviewed-By: Ruben Bridgewater &amp;lt;ruben@bridgewater.de&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/5b9ef11e35e551a101d970dbdbb45618267da77c</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/5b9ef11e35e551a101d970dbdbb45618267da77c"/>
+    <title>
+        timers: fix priority queue removeAt
+    </title>
+    <updated>2018-11-15T17:56:04Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/20809?s=30&amp;v=4"/>
+    <author>
+      <name>apapirovski</name>
+      <uri>https://github.com/apapirovski</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;timers: fix priority queue removeAt
+
+PR-URL: https://github.com/nodejs/node/pull/24322
+Fixes: https://github.com/nodejs/node/issues/24320
+Fixes: https://github.com/nodejs/node/issues/24362
+Reviewed-By: Colin Ihrig &amp;lt;cjihrig@gmail.com&amp;gt;
+Reviewed-By: Ruben Bridgewater &amp;lt;ruben@bridgewater.de&amp;gt;
+Reviewed-By: Matteo Collina &amp;lt;matteo.collina@gmail.com&amp;gt;
+Reviewed-By: Franziska Hinkelmann &amp;lt;franziska.hinkelmann@gmail.com&amp;gt;
+Reviewed-By: Benjamin Gruenbaum &amp;lt;benjamingr@gmail.com&amp;gt;
+Reviewed-By: Weijia Wang &amp;lt;starkwang@126.com&amp;gt;
+Reviewed-By: Jeremiah Senkpiel &amp;lt;fishrock123@rocketmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/dc26247e69d1ebc61c86b42c027f70da917202ce</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/dc26247e69d1ebc61c86b42c027f70da917202ce"/>
+    <title>
+        test: deep object to table not covered
+    </title>
+    <updated>2018-11-15T15:12:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/2674679?s=30&amp;v=4"/>
+    <author>
+      <name>ovhemert</name>
+      <uri>https://github.com/ovhemert</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;test: deep object to table not covered
+
+PR-URL: https://github.com/nodejs/node/pull/24257
+Reviewed-By: Weijia Wang &amp;lt;starkwang@126.com&amp;gt;
+Reviewed-By: James M Snell &amp;lt;jasnell@gmail.com&amp;gt;
+Reviewed-By: Luigi Pinca &amp;lt;luigipinca@gmail.com&amp;gt;
+Reviewed-By: Ruben Bridgewater &amp;lt;ruben@bridgewater.de&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b7aded3300269bc36d1a14b474c4a85e185189d4</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/b7aded3300269bc36d1a14b474c4a85e185189d4"/>
+    <title>
+        src: compile native modules and their code cache in C++
+    </title>
+    <updated>2018-11-15T15:12:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/4299420?s=30&amp;v=4"/>
+    <author>
+      <name>joyeecheung</name>
+      <uri>https://github.com/joyeecheung</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;src: compile native modules and their code cache in C++
+
+This patch refactors out a part of NativeModule.prototype.compile
+(in JS land) into a C++ NativeModule class, this enables a
+couple of possibilities:
+
+1. By moving the code to the C++ land, we have more opportunity
+  to specialize the compilation process of the native modules
+  (e.g. compilation options, code cache) that is orthogonal to
+  how user land modules are compiled
+2. We can reuse the code to compile bootstrappers and context
+  fixers and enable them to be compiled with the code cache later,
+  since they are not loaded by NativeModule in the JS land their
+  caching must be done in C++.
+3. Since there is no need to pass the static data to JS for
+  compilation anymore, this enables us to use
+  (std::map&amp;lt;std::string, const char*&amp;gt;) in the generated
+  node_code_cache.cc and node_javascript.cc later, and scope
+  every actual access to the source of native modules to a
+  std::map lookup instead of a lookup on a v8::Object in
+  dictionary mode.
+
+This patch also refactor the code cache generator and tests
+a bit and trace the `withCodeCache` and `withoutCodeCache`
+in a Set instead of an Array, and makes sure that all the cachable
+builtins are tested.
+
+PR-URL: https://github.com/nodejs/node/pull/24221
+Reviewed-By: Refael Ackermann &amp;lt;refack@gmail.com&amp;gt;
+Reviewed-By: Anna Henningsen &amp;lt;anna@addaleax.net&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4709fe676d6c49b075de9368d3180a6e5104aee3</id>
+    <link type="text/html" rel="alternate" href="https://github.com/nodejs/node/commit/4709fe676d6c49b075de9368d3180a6e5104aee3"/>
+    <title>
+        win: add customization warning to tools script
+    </title>
+    <updated>2018-11-15T15:12:26Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars2.githubusercontent.com/u/134460?s=30&amp;v=4"/>
+    <author>
+      <name>joaocgreis</name>
+      <uri>https://github.com/joaocgreis</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;win: add customization warning to tools script
+
+PR-URL: https://github.com/nodejs/node/pull/24348
+Reviewed-By: Refael Ackermann &amp;lt;refack@gmail.com&amp;gt;
+Reviewed-By: Vse Mozhet Byt &amp;lt;vsemozhetbyt@gmail.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+</feed>


### PR DESCRIPTION
Parse the release notes for a release to determine if it is a security
release.

Refs: https://github.com/nodejs/Release/issues/437
Refs: https://github.com/nodejs/node/pull/27612#issuecomment-490698922

This is an alternative to https://github.com/nodejs/nodejs-dist-indexer/pull/8 and can be applied retroactively if the
index is rebuilt. The first line of the release notes should contain
`This is a security release.` which does appear to be the 
convention for the recent security releases AFAICT.