### PR TITLE
only check mtime of files, not dirs to determine release date

### DIFF
--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -367,7 +367,7 @@ function dirDate (dir, callback) {
 
     function mtime (file, callback) {
       fs.stat(path.join(argv.dist, dir, file), function (err, stat) {
-        callback(null, stat && stat.mtime)
+        callback(null, stat && stat.isFile() && stat.mtime)
       })
     }
 

--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -366,8 +366,17 @@ function dirDate (dir, callback) {
     map(files, mtime, afterMap)
 
     function mtime (file, callback) {
+      const ignoreDirectoryDate = new Date('2019-10-01')
       fs.stat(path.join(argv.dist, dir, file), function (err, stat) {
-        callback(null, stat && stat.isFile() && stat.mtime)
+        if (err || !stat) {
+          return callback(err)
+        }
+        if (!stat.isFile() && stat.mtime >= ignoreDirectoryDate) {
+          // is a directory, but we stopped using directories as a date reference in Oct-19
+          // and don't want to rewrite old dates
+          return callback(null)
+        }
+        callback(null, stat.mtime) // is a file
       })
     }
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/1988

Here's the tricky thing though, it's going to change some dates and I have no idea what the implications of that might be. Who knows what these dates are going to be used for! Here's a quick analysis by generating an index.json with this change and comparing it with the old. They're mostly a day out but there are some larger gaps:

v13.0.0 changes from 2019-10-10 to 2019-10-22
v12.5.0 changes from 2019-06-26 to 2019-06-27
v11.14.0 changes from 2019-04-10 to 2019-04-11
v11.12.0 changes from 2019-03-14 to 2019-03-15
v11.1.0 changes from 2018-10-30 to 2018-11-02
v10.17.0 changes from 2019-10-21 to 2019-10-22
v10.11.0 changes from 2018-09-19 to 2018-09-20
v10.1.0 changes from 2018-05-08 to 2018-05-09
v8.16.2 changes from 2019-10-08 to 2019-10-09
v8.9.4 changes from 2018-01-02 to 2018-01-03
v8.9.3 changes from 2017-12-07 to 2017-12-08
v8.3.0 changes from 2017-08-08 to 2017-08-09
v7.10.0 changes from 2017-05-02 to 2017-05-03
v7.7.0 changes from 2017-02-28 to 2017-03-01
v6.13.0 changes from 2018-02-10 to 2018-02-13
v6.11.1 changes from 2017-07-10 to 2017-07-11
v6.10.0 changes from 2017-02-21 to 2017-02-22
v6.4.0 changes from 2016-08-12 to 2016-08-15
v6.2.2 changes from 2016-06-16 to 2016-06-17
v5.9.1 changes from 2016-03-22 to 2016-03-23
v5.3.0 changes from 2015-12-15 to 2015-12-16
v4.4.4 changes from 2016-05-05 to 2016-05-06
v4.4.0 changes from 2016-03-08 to 2016-03-09
v0.11.14 changes from 2014-08-19 to 2014-09-24
v0.10.33 changes from 2014-10-21 to 2014-10-23
v0.9.2 changes from 2012-09-17 to 2012-09-18
v0.8.6 changes from 2012-08-06 to 2012-08-07
v0.8.3 changes from 2012-07-17 to 2012-07-19
v0.8.0 changes from 2012-06-22 to 2012-06-25
v0.7.1 changes from 2012-01-23 to 2012-01-24
v0.6.18 changes from 2012-05-14 to 2012-05-15
v0.6.16 changes from 2012-04-27 to 2012-04-30
v0.6.9 changes from 2012-01-27 to 2012-01-28
v0.6.0 changes from 2011-11-04 to 2011-11-05
v0.5.7 changes from 2011-09-16 to 2011-09-17
v0.5.6 changes from 2011-08-26 to 2011-09-09

An alternative might be to switch on version. In that bit of code we have `dir` and we could get the major version number from it because it'll start with a `vX.`. Check that, if >= 13, don't include directories, otherwise do it the old way.

Is it worth the bother? I don't know!