### PR TITLE
exclude `NODE_EMBEDDER_MODULE_VERSION` string

### DIFF
--- a/dist-indexer.js
+++ b/dist-indexer.js
@@ -325,7 +325,7 @@ function fetchModVersion (gitref, callback) {
       return callback(err)
     }
 
-    let m = rawData.match(/^#define NODE_MODULE_VERSION\s+([^\s]+)\s+.+$/m)
+    let m = rawData.match(/^#define NODE_MODULE_VERSION\s+((?!NODE_EMBEDDER_MODULE_VERSION)[^\s]+)\s+.+$/m)
     version = m && m[1]
 
     if (version) {


### PR DESCRIPTION
When extracting the module version from `src/node_version.h`, ignore the line:
```
#define NODE_MODULE_VERSION NODE_EMBEDDER_MODULE_VERSION
```
This will pick up the default value from the header as the official Node.js builds do not define `NODE_EMBEDDER_MODULE_VERSION`.

Fixes: https://github.com/nodejs/nodejs-dist-indexer/issues/20
Refs: https://github.com/nodejs/node/pull/49279