### PR TITLE
feat: add x64-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ OS / architecture / packaging specifiers used in the listings include:
 * **linux-riscv64**: normally .tar.gz and .tar.xz
 * **linux-s390x**: normally .tar.gz and .tar.xz
 * **linux-x64**: normally .tar.gz and .tar.xz
+* **linux-x64-debug**: normally .tar.gz and .tar.xz
 * **linux-x64-glibc-217**: normally .tar.gz and .tar.xz
 * **linux-x86**: normally .tar.gz and .tar.xz
 * **osx-arm64-tar**: normally .tar.gz and .tar.xz

--- a/transform-filename.js
+++ b/transform-filename.js
@@ -41,6 +41,7 @@ const types = {
   'linux-x64-musl': 'linux-x64-musl',
   'linux-x64-pointer-compression': 'linux-x64-pointer-compression',
   'linux-x64-usdt': 'linux-x64-usdt',
+  'linux-x64-debug': 'linux-x64-debug',
   'win-arm64.7z': 'win-arm64-7z',
   'win-arm64.zip': 'win-arm64-zip'
 }
@@ -170,6 +171,8 @@ if (module === require.main) {
     { file: 'node-v14.13.0-linux-x64-pointer-compression.tar.xz' },
     { file: 'node-v14.13.0-linux-x64-usdt.tar.gz', type: 'linux-x64-usdt' },
     { file: 'node-v14.13.0-linux-x64-usdt.tar.xz' },
+    { file: 'node-v14.13.0-linux-x64-debug.tar.gz', type: 'linux-x64-debug' },
+    { file: 'node-v14.13.0-linux-x64-debug.tar.xz' },
     { file: 'node-v14.13.0-win-arm64.zip', type: 'win-arm64-zip' },
     { file: 'node-v14.13.0-win-arm64.7z', type: 'win-arm64-7z' }
   ]


### PR DESCRIPTION
This adds support for an unofficial-build that is added in [nodejs/unofficial-builds#107](https://github.com/nodejs/unofficial-builds/pull/107)

attn: @rvagg 