### PR TITLE
chore(ci): give release job permission to write to repo

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,4 +1,6 @@
 name: Test & Maybe Release
+permissions:
+  contents: write
 on: [push, pull_request]
 jobs:
   test:


### PR DESCRIPTION
Ref: https://github.com/nodejs/nodejs-dist-indexer/issues/39