### PR TITLE
chore(ci): slower dependabot, pin action hashes, clean up release process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,26 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 5
+    groups:
+      github-actions-minor-patch:
+        patterns: ['*']
+        update-types: ['minor', 'patch']
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 5
+    groups:
+      npm-minor-patch:
+        patterns: ['*']
+        update-types: ['minor', 'patch']

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,19 +5,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.x, lts/*, current]
+        node: [lts/*, current]
         # not quite windows ready, halp! os: [macos-latest, ubuntu-latest, windows-latest]
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
+          check-latest: true
       - name: Set up ghauth config (Ubuntu)
         run: |
           mkdir -p ~/.config/changelog-maker/
@@ -53,31 +54,20 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: |
           npm install --no-progress --no-package-lock --no-save
       - name: Build
-        run: |
-          npm run build
-      - name: Install plugins
-        run: |
-          npm install \
-            @semantic-release/commit-analyzer \
-            conventional-changelog-conventionalcommits \
-            @semantic-release/release-notes-generator \
-            @semantic-release/npm \
-            @semantic-release/github \
-            @semantic-release/git \
-            @semantic-release/changelog \
-            --no-progress --no-package-lock --no-save
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,44 @@
 ## [1.8.22](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.21...v1.8.22) (2026-07-30)
 
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.10 to 7.0.11 ([#93](https://github.com/nodejs/nodejs-dist-indexer/issues/93)) ([b3bc0c6](https://github.com/nodejs/nodejs-dist-indexer/commit/b3bc0c64b75d2e5f8cd06ebe738e029c949c2f67))
+
 ## [1.8.21](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.20...v1.8.21) (2026-07-29)
+
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.8 to 7.0.10 ([#92](https://github.com/nodejs/nodejs-dist-indexer/issues/92)) ([ea0ba18](https://github.com/nodejs/nodejs-dist-indexer/commit/ea0ba184519bf77cedba52e64ac9d3899ba43571))
 
 ## [1.8.20](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.19...v1.8.20) (2026-07-27)
 
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.7 to 7.0.8 ([#91](https://github.com/nodejs/nodejs-dist-indexer/issues/91)) ([84b1d58](https://github.com/nodejs/nodejs-dist-indexer/commit/84b1d5812bf51421658dbac9054eb39390ca7cdf))
+
 ## [1.8.19](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.18...v1.8.19) (2026-07-21)
+
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.6 to 7.0.7 ([#90](https://github.com/nodejs/nodejs-dist-indexer/issues/90)) ([4d481c8](https://github.com/nodejs/nodejs-dist-indexer/commit/4d481c8e2d4116bb84121a2bc65f63215bea18a5))
 
 ## [1.8.18](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.17...v1.8.18) (2026-07-16)
 
+### Trivial Changes
+
+* **deps:** bump actions/setup-node from 6.4.0 to 7.0.0 ([#89](https://github.com/nodejs/nodejs-dist-indexer/issues/89)) ([0d56069](https://github.com/nodejs/nodejs-dist-indexer/commit/0d560696b44b29e11818603d7baea0138e58cb00))
+
 ## [1.8.17](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.16...v1.8.17) (2026-07-03)
 
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.5 to 7.0.6 ([#88](https://github.com/nodejs/nodejs-dist-indexer/issues/88)) ([005e603](https://github.com/nodejs/nodejs-dist-indexer/commit/005e603c73dd4c7cb8eef960a87e720d18e37048))
+
 ## [1.8.16](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.15...v1.8.16) (2026-06-30)
+
+### Trivial Changes
+
+* **deps:** bump bl from 7.0.4 to 7.0.5 ([#87](https://github.com/nodejs/nodejs-dist-indexer/issues/87)) ([8bfce21](https://github.com/nodejs/nodejs-dist-indexer/commit/8bfce216a22d255bbf78b4ceb1282fe1cae98a11))
 
 ## [1.8.15](https://github.com/nodejs/nodejs-dist-indexer/compare/v1.8.14...v1.8.15) (2026-06-23)
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
   },
   "preferGlobal": true,
   "devDependencies": {
+    "@semantic-release/changelog": "^7.0.0",
+    "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/git": "^11.0.0",
+    "@semantic-release/github": "^12.0.6",
+    "@semantic-release/npm": "^13.1.5",
+    "@semantic-release/release-notes-generator": "^14.1.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
+    "semantic-release": "^25.0.3",
     "standard": "^17.1.0"
   },
   "release": {
@@ -92,6 +100,30 @@
                 "section": "Bug Fixes"
               },
               {
+                "type": "perf",
+                "section": "Performance Improvements"
+              },
+              {
+                "type": "revert",
+                "section": "Reverts"
+              },
+              {
+                "type": "refactor",
+                "section": "Code Refactoring"
+              },
+              {
+                "type": "test",
+                "section": "Tests"
+              },
+              {
+                "type": "build",
+                "section": "Trivial Changes"
+              },
+              {
+                "type": "ci",
+                "section": "Trivial Changes"
+              },
+              {
                 "type": "chore",
                 "section": "Trivial Changes"
               },
@@ -100,8 +132,8 @@
                 "section": "Trivial Changes"
               },
               {
-                "type": "test",
-                "section": "Tests"
+                "type": "style",
+                "section": "Trivial Changes"
               }
             ]
           }


### PR DESCRIPTION
also downgrades conventional-changelog-conventionalcommits to v9 because v10 is borked; for now.